### PR TITLE
chore: add sleep command to jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
                 checkout scm
                 sh 'cp env/sample.dev.env .env'
                 sh 'make start-ci -- -d --build'
+                sleep(5)
             }
         }
         stage('Test') {


### PR DESCRIPTION
This is a short-term solution to make sure the database is ready to accept to accept connections before running tests