### PR TITLE
feat: validate headers for team endpoints

### DIFF
--- a/src/controllers/team_detail.py
+++ b/src/controllers/team_detail.py
@@ -6,6 +6,10 @@ from ..exceptions import BadRequestError, ForbiddenError
 from ..models import Team, TeamMembership, User
 from ..utils.is_valid_uuid import is_valid_uuid
 from ..utils.controller_decorators import call_before, get_resource, format_response
+from ..utils.controller_validators import (
+    validate_accept_header,
+    validate_content_type_header,
+)
 
 
 def validate_uuid(*args, team_id):
@@ -24,7 +28,7 @@ def validate_permissions(*args, team):
 
 def make_parser():
     parser = reqparse.RequestParser()
-    parser.add_argument(name="name", nullable=False, location="form")
+    parser.add_argument(name="name", nullable=False, location="json")
     return parser
 
 
@@ -34,7 +38,7 @@ class TeamDetail(Resource):
         self.parser = make_parser()
 
     @jwt_required
-    @call_before([validate_uuid])
+    @call_before([validate_accept_header, validate_uuid])
     @get_resource(Team)
     @format_response(
         {
@@ -58,7 +62,7 @@ class TeamDetail(Resource):
         return team
 
     @jwt_required
-    @call_before([validate_uuid])
+    @call_before([validate_accept_header, validate_content_type_header, validate_uuid])
     @get_resource(Team)
     @call_before([validate_permissions])
     @format_response(
@@ -74,7 +78,7 @@ class TeamDetail(Resource):
         return team
 
     @jwt_required
-    @call_before([validate_uuid])
+    @call_before([validate_accept_header, validate_uuid])
     @get_resource(Team)
     @call_before([validate_permissions])
     def delete(self, team):

--- a/src/controllers/team_list.py
+++ b/src/controllers/team_list.py
@@ -4,17 +4,21 @@ from flask_jwt_extended import jwt_required
 from ..db import DB
 from ..exceptions import BadRequestError
 from ..models import Team, TeamMembership, User
-from ..utils.controller_decorators import format_response
+from ..utils.controller_decorators import call_before, format_response
+from ..utils.controller_validators import (
+    validate_accept_header,
+    validate_content_type_header,
+)
 
 
 def make_parser():
     parser = reqparse.RequestParser()
-    parser.add_argument(name="name", required=True, nullable=False, location="form")
+    parser.add_argument(name="name", required=True, nullable=False, location="json")
     parser.add_argument(
         name="team_members",
         required=True,
         nullable=False,
-        location="form",
+        location="json",
         action="append",
     )
     return parser
@@ -26,6 +30,7 @@ class TeamList(Resource):
         self.parser = make_parser()
 
     @jwt_required
+    @call_before([validate_accept_header])
     @format_response(
         {
             "name": "teams",
@@ -48,6 +53,7 @@ class TeamList(Resource):
         return Team.query.all()
 
     @jwt_required
+    @call_before([validate_accept_header, validate_content_type_header])
     @format_response(
         {
             "name": "teams",


### PR DESCRIPTION
Resolves #30 

I won't be adding these header validations to the `/team_memberships` endpoints because I'll be removing those endpoints anyway.